### PR TITLE
Final trickle button for the end of the article

### DIFF
--- a/example.json
+++ b/example.json
@@ -7,7 +7,8 @@
     "body":"Body text for article",
     "_trickle": {
         "button": {
-            "continue" : "Move on"
+            "continue" : "Move on",
+            "final": "Finished!"
         }
     }
 },

--- a/example.json
+++ b/example.json
@@ -6,10 +6,19 @@
     "title":"Article 1 title",
     "body":"Body text for article",
     "_trickle": {
-        "button": {
-            "continue" : "Move on",
-            "final": "Finished!"
-        }
+        "button": "Move on"
+    }
+},
+{
+    "_id":"a-31",
+    "_parentId":"co-20",
+    "_type":"article",
+    "_classes":"",
+    "title":"Article 1 title",
+    "body":"Body text for article",
+    "_trickle": {
+        "button": "Next",
+        "finalButton": "Finished!"
     }
 },
 {

--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -14,7 +14,8 @@ define(function(require) {
             className: "extension-trickle",
 
             events: {
-                'click .trickle-button':'onTrickleButtonClicked'
+                'click .trickle-button':'onTrickleButtonClicked',
+                'click [data-event="menu"]':'onMenuClicked'
             },
 
             initialize: function() {
@@ -131,6 +132,10 @@ define(function(require) {
             blockSetToComplete: function(block) {
                 // Index here is plus one
                 if (this.trickleCurrentIndex == this.pageElements.length) {
+                    var finalElement = this.pageElements[this.pageElements.length-1];
+                    if(finalElement.get('_trickle') && finalElement.get('_trickle').button &&  finalElement.get('_trickle').button.final) {
+                        this.showFinal(finalElement);
+                    }
                     return;
                 }
                 if  (this.pageElements[this.trickleCurrentIndex-1].get('_trickle')){
@@ -176,6 +181,11 @@ define(function(require) {
                 }, this));
             },
 
+            onMenuClicked: function(event) {
+                event.preventDefault();
+                Adapt.trigger('navigation:menu');
+            },
+
             showTrickle: function () {
                 var buttonView = new TrickleButtonView({
                     model: this.pageElements[this.trickleCurrentIndex-1]
@@ -183,6 +193,14 @@ define(function(require) {
 
                 this.$el.html(buttonView.$el).show();
                 this.$('.trickle-button').addClass('trickle-button-show');
+            },
+
+            showFinal: function (pageElement) {
+                var buttonView = new TrickleFinalButtonView({
+                    model: pageElement
+                });
+                this.$el.html(buttonView.$el).show();
+                this.$('.trickle-final').addClass('trickle-button-show');
             },
 
             hideTrickle: function() {
@@ -202,6 +220,8 @@ define(function(require) {
         });
 
         var TrickleButtonView = Backbone.View.extend({
+            templateName: "trickle-button",
+
             initialize: function(){
                 this.render();
                 this.listenTo(Adapt, 'remove', this.remove);
@@ -209,10 +229,14 @@ define(function(require) {
 
             render: function () {
                 var data = this.model.toJSON();
-                var template = Handlebars.templates["trickle-button"];
+                var template = Handlebars.templates[this.templateName];
                 this.$el.html(template(data));
                 return this;
             }
+        });
+
+        var TrickleFinalButtonView = TrickleButtonView.extend({
+            templateName: "trickle-final"
         });
 
         new TrickleView({model: pageModel});

--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -135,7 +135,7 @@ define(function(require) {
                 // Index here is plus one
                 if (this.trickleCurrentIndex == this.pageElements.length) {
                     var finalElement = this.pageElements[this.pageElements.length-1];
-                    if(finalElement.get('_trickle') && finalElement.get('_trickle').button &&  finalElement.get('_trickle').button.final) {
+                    if(finalElement.get('_trickle') && finalElement.get('_trickle').finalButton) {
                         this.showFinal(finalElement);
                     }
                     return;

--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -81,7 +81,7 @@ define(function(require) {
             startTrickle: function(pageView) {
                 this.trickleCurrentIndex = 0;
                 this.trickleStarted = true;
-                this.pageElements[this.trickleCurrentIndex].set('_isVisible', true);               
+                this.pageElements[this.trickleCurrentIndex].set('_isVisible', true);
             },
 
             elementSetToVisible: function(element) {
@@ -122,8 +122,7 @@ define(function(require) {
                         return;
                     }
                     this.changeTrickleCurrentIndex();
-                    if (!this.pageElements[this.trickleCurrentIndex].get('_trickle') 
-                    && this.pageElements[this.trickleCurrentIndex].get('_type') == 'block') {
+                    if (!this.pageElements[this.trickleCurrentIndex].get('_trickle') && this.pageElements[this.trickleCurrentIndex].get('_type') == 'block') {
                         this.setItemToVisible(this.pageElements[this.trickleCurrentIndex]);
                     }
                 }
@@ -174,7 +173,7 @@ define(function(require) {
                     this.setItemToVisible(this.pageElements[this.trickleCurrentIndex]);
                 }
                 this.hideTrickle();
-                
+
                 _.defer(_.bind(function() {
                     Adapt.trigger('device:screenSize', Adapt.device.screenWidth);
                     this.scrollToItem(currentTrickleItem);
@@ -183,7 +182,7 @@ define(function(require) {
 
             onMenuClicked: function(event) {
                 event.preventDefault();
-                Adapt.trigger('navigation:menu');
+                Adapt.trigger('navigation:backButton');
             },
 
             showTrickle: function () {

--- a/less/trickle.less
+++ b/less/trickle.less
@@ -15,6 +15,10 @@
     padding: @item-padding;
   }
 
+  .trickle-final {
+    .trickle-button;
+  }
+
   .trickle-button-show {
     display:block;
     visibility:visible;

--- a/templates/trickle-final.hbs
+++ b/templates/trickle-final.hbs
@@ -1,6 +1,6 @@
 {{! Maintainers - Chris Jones}}
 <a href="#" class="trickle-final" data-event="menu" alt="Menu">
   <h6>
-    {{{_trickle.button.final}}}
+    {{{_trickle.finalButton}}}
   </h6>
 </a>

--- a/templates/trickle-final.hbs
+++ b/templates/trickle-final.hbs
@@ -1,0 +1,6 @@
+{{! Maintainers - Chris Jones}}
+<a href="#" class="trickle-final" data-event="menu" alt="Menu">
+  <h6>
+    {{{_trickle.button.final}}}
+  </h6>
+</a>


### PR DESCRIPTION
I've added a FinalButtonView so that the last block in the article doesn't leave you hanging.

The default behavior is as before, but now if ```_trickle.button.final``` is set on the block then it will show last trickle button that takes you back to the parent menu.