### PR TITLE
Update adapt-contrib-trickle.js

### DIFF
--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -136,12 +136,15 @@ define(function(require) {
                 if (this.trickleCurrentIndex == this.pageElements.length) {
                     return;
                 }
-                if  (this.pageElements[this.trickleCurrentIndex-1].get('_trickle')){
-                    this.showTrickle();
-                } else if (this.pageElements[this.trickleCurrentIndex].get('_trickle')){
-                    this.showTrickle();
-                } else if (!this.pageElements[this.trickleCurrentIndex].get('_trickle')) {
-                    this.setItemToVisible(this.pageElements[this.trickleCurrentIndex]);
+                var currentElement = this.pageElements[this.trickleCurrentIndex-1];
+                var nextElement = this.pageElements[this.trickleCurrentIndex];
+                
+                if  (currentElement.get('_trickle')){
+                    this.showTrickle(currentElement);
+                } else if (nextElement.get('_trickle') && currentElement.get('_id') == block.get('_id')){
+                    this.showTrickle(nextElement);
+                } else if (!nextElement.get('_trickle')) {
+                    this.setItemToVisible(nextElement);
                 }
             },
 
@@ -182,9 +185,9 @@ define(function(require) {
                 }, this));
             },
 
-            showTrickle: function () {
+            showTrickle: function (pModel) {
                 var buttonView = new TrickleButtonView({
-                    model: this.pageElements[this.trickleCurrentIndex-1]
+                    model: pModel || this.pageElements[this.trickleCurrentIndex-1]
                 });
 
                 this.$el.html(buttonView.$el).show();


### PR DESCRIPTION
This is to resolve issue mentioned here: https://community.adaptlearning.org/mod/forum/discuss.php?d=526 and here: https://github.com/adaptlearning/adapt-contrib-trickle/issues/30

I'm checking if block that issued the completion is next to be trickled and then allow for showTrickle - this solved the issue with showing the trickle button prematurely when _trickle was not on first (block/article).

Adding the model argument to the showTrickle allows to specify which model should be used to pick the button settings - this solved the "Continue" label instead of customised.