### PR TITLE
Trickle with auto-padding

### DIFF
--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -187,11 +187,14 @@ define(function(require) {
                     model: this.pageElements[this.trickleCurrentIndex-1]
                 });
 
+                $('body').addClass('trickle-body-padding');
+                window.scrollTo(0,$('body')[0].scrollHeight);//could it be animated?
                 this.$el.html(buttonView.$el).show();
                 this.$('.trickle-button').addClass('trickle-button-show');
             },
 
             hideTrickle: function() {
+                $('body').removeClass('trickle-body-padding');
                 this.$el.hide();
             },
 

--- a/less/trickle.less
+++ b/less/trickle.less
@@ -37,3 +37,8 @@
   display:none;
   visibility:hidden;
 }
+
+.trickle-body-padding {
+    //size of the trickle button
+    padding-bottom: 46px;//trickle height+padding
+}


### PR DESCRIPTION
This PR is to resolve issue [adapt-contrib-trickle/issues/32](https://github.com/adaptlearning/adapt-contrib-trickle/issues/32), it defines a class with padding-bottom rule taht is added/removed to the body tag when trickle button is visible/hidden.