### PR TITLE
Fix issue with trickle

### DIFF
--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -194,7 +194,7 @@ define(function(require) {
                 this.$('.trickle-button').addClass('trickle-button-show');
             },
 
-            hideTrickle: function(blockId) {
+            hideTrickle: function() {
                 $(".block").removeClass('trickle-body-padding');
                 this.$el.hide();
             },

--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -137,9 +137,9 @@ define(function(require) {
                     return;
                 }
                 if  (this.pageElements[this.trickleCurrentIndex-1].get('_trickle')){
-                    this.showTrickle();
+                    this.showTrickle(this.pageElements[this.trickleCurrentIndex-1].get('_id'));
                 } else if (this.pageElements[this.trickleCurrentIndex].get('_trickle')){
-                    this.showTrickle();
+                    this.showTrickle(this.pageElements[this.trickleCurrentIndex].get('_id'));
                 } else if (!this.pageElements[this.trickleCurrentIndex].get('_trickle')) {
                     this.setItemToVisible(this.pageElements[this.trickleCurrentIndex]);
                 }
@@ -176,6 +176,7 @@ define(function(require) {
                     this.setItemToVisible(this.pageElements[this.trickleCurrentIndex]);
                 }
                 this.hideTrickle();
+
                 
                 _.defer(_.bind(function() {
                     Adapt.trigger('device:screenSize', Adapt.device.screenWidth);
@@ -183,18 +184,18 @@ define(function(require) {
                 }, this));
             },
 
-            showTrickle: function () {
+            showTrickle: function (blockId) {
                 var buttonView = new TrickleButtonView({
                     model: this.pageElements[this.trickleCurrentIndex-1]
                 });
-                $('body').addClass('trickle-body-padding');
+                $("."+blockId).addClass('trickle-body-padding');
                 window.scrollTo(0,$('body')[0].scrollHeight);//could it be animated?
                 this.$el.html(buttonView.$el).show();
                 this.$('.trickle-button').addClass('trickle-button-show');
             },
 
-            hideTrickle: function() {
-                $('body').removeClass('trickle-body-padding');
+            hideTrickle: function(blockId) {
+                $(".block").removeClass('trickle-body-padding');
                 this.$el.hide();
             },
 

--- a/less/trickle.less
+++ b/less/trickle.less
@@ -1,5 +1,6 @@
 .extension-trickle {
   text-align: center;
+  display:none;
 
   .trickle-button {
     display:none;


### PR DESCRIPTION
On completing blocks in an article, going back to the menu and returning back to the article the trickle element is still visible. 
In the current Adapt develop branch is hard to notice this, but if you inspect the element you will notice that the following div is visible.

`<div class="extension-trickle"></div>`

This line prevent this from happening.

