### PR TITLE
Added trickle:kill event

### DIFF
--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -109,6 +109,8 @@ define([
             this.listenTo(Adapt, "steplocking:unwait", this.onStepUnlockUnwait);
 
             this.listenTo(Adapt, "trickle:relativeScrollTo", this.relativeScrollTo);
+
+            this.listenTo(Adapt, "trickle:kill", this.endTrickle);
         },
 
         initializePage: function(view) {

--- a/js/trickle-buttonView.js
+++ b/js/trickle-buttonView.js
@@ -84,6 +84,7 @@ define([
             this.listenTo(this.model, "change:_isEnabled", this.onEnabledChange);
             this.listenTo(this.model, "change:_isVisible", this.onVisibilityChange);
             this.listenToOnce(Adapt, "remove", this.onRemove);
+            this.listenToOnce(Adapt, "trickle:kill", this.onRemove);
         },
 
         toggleLock: function(bool) {


### PR DESCRIPTION
Allows other extensions to remove trickle from the page. Useful for testing etc.