### PR TITLE
hotfix/resize: stop resize call without resize

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-trickle",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-trickle",
   "issues": "https://adaptlearning.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10100&issuetype=1&priority=6&components=10513",

--- a/js/lib/jquery.resize.js
+++ b/js/lib/jquery.resize.js
@@ -107,8 +107,11 @@
   function triggerResize(item) {
     var measure = getDimensions(item.$element);
     //check if measure has the same values as last
+    var isFirstRun = false;
+    if (item._resizeData === undefined) isFirstRun = true;
     if (item._resizeData !== undefined && item._resizeData === measure.uniqueMeasurementId) return;
     item._resizeData = measure.uniqueMeasurementId;
+    if (isFirstRun) return;
     
     //make sure to keep listening until no more resize changes are found
     loopData.lastEvent = (new Date()).getTime();


### PR DESCRIPTION
a resize event is triggered on the first click, this fixes that call.