### PR TITLE
accessibility: issue/#2168 Switched to use Adapt.getOffset

### DIFF
--- a/js/handlers/resize.js
+++ b/js/handlers/resize.js
@@ -51,7 +51,7 @@ define([
 
         onTrickleResize: function() {
             if (!this.isStepLocking) return;
-            var offset = this.stepView.$el.offset();
+            var offset = Adapt.getOffset(this.stepView.$el);
             var height = this.stepView.$el.height();
 
             var topPadding = parseInt($("#wrapper").css("padding-top") || "0");


### PR DESCRIPTION
[#2168](https://github.com/adaptlearning/adapt_framework/issues/2168)
* Utilize `Adapt.getOffset(selector)` to assess where the `#wrapper` should be cut off for trickle

#### Test with
[fwk#2169](https://github.com/adaptlearning/adapt_framework/pull/2169)