### PR TITLE
reverts change to make trickle enabled by default on all blocks

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -71,7 +71,7 @@
                 "_scrollDuration": {
                   "type": "number",
                   "required": true,
-                  "default": "500",
+                  "default": 500,
                   "title": "Scroll Duration",
                   "inputType": "Number",
                   "validators": ["required", "number"],
@@ -251,7 +251,7 @@
                 "_scrollDuration": {
                   "type": "number",
                   "required": true,
-                  "default": "500",
+                  "default": 500,
                   "title": "Scroll Duration",
                   "inputType": "Number",
                   "validators": ["required", "number"],

--- a/properties.schema
+++ b/properties.schema
@@ -236,7 +236,7 @@
                 "_isEnabled": {
                   "type": "boolean",
                   "required": false,
-                  "default": true,
+                  "default": false,
                   "title": "Enable Trickle",
                   "inputType": "Checkbox",
                   "validators": []


### PR DESCRIPTION
as this creates a poor experience for authoring tool users

also amend `_scrollDuration` default to remove quotes - value is a Number not String