### PR TITLE
accessibility: issue/2077 Trickle will focus with autoScroll: false

### DIFF
--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -42,13 +42,13 @@ define([
         getModelConfig: function(model) {
             return model.get("_trickle");
         },
-        
+
         getCompletionAttribute: function() {
             var trickle = this.getModelConfig(Adapt.config);
             if (!trickle) return "_isComplete";
             return trickle._completionAttribute || "_isComplete";
         },
-        
+
         setModelConfig: function(model, config) {
             return model.set("_trickle", config);
         },
@@ -62,7 +62,7 @@ define([
 
         onPagePreRender: function(view) {
             this.pageView = new PageView({
-                model: view.model, 
+                model: view.model,
                 el: view.el
             });
         },
@@ -83,12 +83,12 @@ define([
                 switch (scrollTo.substr(0,1)) {
                 case "@":
                     //NAVIGATE BY RELATIVE TYPE
-                    
+
                     //Allows trickle to scroll to a sibling / cousin component relative to the current trickle item
                     var relativeModel = fromModel.findRelative(scrollTo, {
                         filterNotAvailable: true
                     });
-                    
+
                     if (relativeModel === undefined) return;
                     scrollToId = relativeModel.get("_id");
 
@@ -99,12 +99,18 @@ define([
                     //NAVIGATE BY CLASS
                     scrollToId = scrollTo.substr(1, scrollTo.length-1);
                     break;
-                default: 
+                default:
                     scrollToId = scrollTo;
                 }
 
                 if (scrollToId == "") return;
-                
+
+                var isAutoScrollOff = (!trickle._autoScroll);
+                if (isAutoScrollOff) {
+                    $("." + scrollToId).focusOrNext();
+                    return false;
+                }
+
                 var duration = fromModel.get("_trickle")._scrollDuration || 500;
                 Adapt.scrollTo("." + scrollToId, { duration: duration });
 
@@ -118,9 +124,6 @@ define([
             var hasScrolled = fromModel.get("_isTrickleAutoScrollComplete");
             if (hasScrolled) return false;
 
-            var isAutoScrollOff = (!trickle._autoScroll);
-            if (isAutoScrollOff) return false;
-
             var isArticleWithOnChildren = (fromModel.get("_type") === "article" && trickle._onChildren);
             if (isArticleWithOnChildren) return false;
 
@@ -128,9 +131,9 @@ define([
         },
 
         onRemove: function() {
-            
+
         }
-                
+
     }, Backbone.Events);
 
     Adapt.trickle.initialize();


### PR DESCRIPTION
[#2077](https://github.com/adaptlearning/adapt_framework/issues/2077)
* Make trickle focus on the next readable element after the trickle button when autoscroll is off

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206.