### PR TITLE
issue/2423: remove resize debounce for synchronous height calculations

### DIFF
--- a/js/handlers/resize.js
+++ b/js/handlers/resize.js
@@ -16,7 +16,7 @@ define([
         },
 
         onAppDataReady: function() {
-            this.onResize = _.debounce(this.onResize.bind(this), 10);
+            this.onResize = this.onResize.bind(this);
             this.preventWrapperScroll = this.preventWrapperScroll.bind(this);
             this.setupEventListeners();
         },


### PR DESCRIPTION
[#2423](https://github.com/adaptlearning/adapt_framework/issues/2423)
* Switched from asynchronous debounced height recalculations to synchronous ones.