### PR TITLE
issue/2518 Focus before scroll

### DIFF
--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -102,9 +102,10 @@ define([
 
             if (scrollToId == "") return;
 
+            $("." + scrollToId).focusOrNext();
+            
             var isAutoScrollOff = (!trickle._autoScroll);
             if (isAutoScrollOff) {
-                $("." + scrollToId).focusOrNext();
                 return false;
             }
 


### PR DESCRIPTION
[#2518](https://github.com/adaptlearning/adapt_framework/issues/2518)
* Focus on next component immediately after button click and before scroll