### PR TITLE
issue/2519 stop #wrapper scrolling with trickle active

### DIFF
--- a/less/trickle.less
+++ b/less/trickle.less
@@ -3,5 +3,6 @@ html.trickle {
 
     #wrapper {
         overflow: hidden;
+        -ms-scroll-limit-y-max: 0;
     }
 }


### PR DESCRIPTION
[#2519](https://github.com/adaptlearning/adapt_framework/issues/2519)
* Prevent wrapper scrolling on ie11

Reference https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-scroll-limit-y-max