### PR TITLE
issue/2512 document.activeElement guard

### DIFF
--- a/js/handlers/buttonView.js
+++ b/js/handlers/buttonView.js
@@ -149,7 +149,7 @@ define([
                 $button.removeClass("disabled").removeAttr("disabled");
                 trickle._button._isDisabled = true;
                 // move focus forward if it's on the aria-label
-                if (document.activeElement.isSameNode(this.$('.aria-label')[0])) {
+                if (document.activeElement && document.activeElement.isSameNode(this.$('.aria-label')[0])) {
                     this.$('.aria-label').focusNext();
                 }
                 // make label unfocusable as it is no longer needed
@@ -303,7 +303,7 @@ define([
             this.isStepLocking = false;
             this.overlayShownCount = 0;
             // move focus forward if it's on the aria-label
-            if (document.activeElement.isSameNode(this.$('.aria-label')[0])) {
+            if (document.activeElement && document.activeElement.isSameNode(this.$('.aria-label')[0])) {
                 this.$('.aria-label').focusNext();
             }
             // make label unfocusable as it is no longer needed


### PR DESCRIPTION
[#2512](https://github.com/adaptlearning/adapt_framework/issues/2520)
* Stopped erroring on no `document.activeElement`