### PR TITLE
FW issue #2657: trickle btn type selector applied dynamically

### DIFF
--- a/less/trickle-button.less
+++ b/less/trickle-button.less
@@ -9,6 +9,10 @@
 
   &__btn {
     display: block;
+    margin: auto;
+  }
+
+  &.is-full-width .trickle__btn {
     width: 100%;
   }
 

--- a/templates/trickle-button.hbs
+++ b/templates/trickle-button.hbs
@@ -4,7 +4,7 @@
 
   <div class="trickle__inner js-trickle-btn-container {{_trickle._button._component}}__inner {{#if _trickle._button._isLocking}} is-locked{{/if}}{{#unless _trickle._button._isVisible}} u-display-none{{/unless}}">
 
-    <button class="btn-text trickle__btn js-trickle-btn {{#if _trickle._button._isDisabled}} is-disabled{{/if}}{{#if _trickle._button._hasIcon}} btn-icon{{/if}}"{{#if _trickle._button._isDisabled}} disabled="disabled"{{/if}}>
+    <button class="trickle__btn js-trickle-btn {{#if _trickle._button._isDisabled}} is-disabled{{/if}}{{#if _trickle._button._hasIcon}} btn-icon{{/if}}{{#any _trickle._button.finalText _trickle._button.text _trickle._button.startText}} btn-text{{/any}}"{{#if _trickle._button._isDisabled}} disabled="disabled"{{/if}}>
 
       {{#if _trickle._button._hasIcon}}
       <div class="trickle__btn-icon">


### PR DESCRIPTION
- btn type selector applied dynamically
- button width removed from generic btn selector and attached to 'is-full-width' instead
- margin applied to center button by default

Fixes [#2657](https://github.com/adaptlearning/adapt_framework/issues/2657)