### PR TITLE
don't set focus when there's no trickle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following attribute can be added to *config.json* to overide which completio
 No known limitations.
 
 ----------------------------
-**Version number:**  4.0.2  <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
+**Version number:**  4.0.3  <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
 **Framework versions:**  5+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-trickle/graphs/contributors)  
 **Accessibility support:** WAI AA  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-trickle",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "framework": ">=5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-trickle",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/example.json
+++ b/example.json
@@ -34,7 +34,7 @@
         }
     }
 
-    // Overide which completion data attribute is used to test when the
+    // Override which completion data attribute is used to test when the
     // trickle button should be displayed
     // Put in config.json
     "_trickle": {

--- a/example.json
+++ b/example.json
@@ -17,7 +17,7 @@
             "_styleBeforeCompletion": "hidden",
             "_comment": "_styleAfterClick = hidden | disabled | scroll",
             "_styleAfterClick": "hidden",
-            "_isFullWidth": true, 
+            "_isFullWidth": true,
             "_comment": "_autoHide = it is recommended this be left set to false in courses that need to be screenreader-compatible.",
             "_autoHide": false,
             "_className": "",
@@ -34,7 +34,7 @@
         }
     }
 
-    // Overide which completion data attribute is used to test when the 
+    // Overide which completion data attribute is used to test when the
     // trickle button should be displayed
     // Put in config.json
     "_trickle": {

--- a/js/adapt-contrib-trickle.js
+++ b/js/adapt-contrib-trickle.js
@@ -17,7 +17,7 @@ define([
 
     initialize: function() {
       this.listenToOnce(Adapt, {
-        "app:dataReady": this.onAppDataReady
+        'app:dataReady': this.onAppDataReady
       });
     },
 
@@ -38,21 +38,21 @@ define([
     },
 
     getModelConfig: function(model) {
-      return model.get("_trickle");
+      return model.get('_trickle');
     },
 
     getCompletionAttribute: function() {
       var trickle = this.getModelConfig(Adapt.config);
-      if (!trickle) return "_isComplete";
-      return trickle._completionAttribute || "_isComplete";
+      if (!trickle) return '_isComplete';
+      return trickle._completionAttribute || '_isComplete';
     },
 
     setModelConfig: function(model, config) {
-      return model.set("_trickle", config);
+      return model.set('_trickle', config);
     },
 
     setupListeners: function() {
-      this.listenTo(Adapt, "pageView:preRender", this.onPagePreRender);
+      this.listenTo(Adapt, 'pageView:preRender', this.onPagePreRender);
     },
 
     onPagePreRender: function(view) {
@@ -67,29 +67,35 @@ define([
 
       if (!this.shouldScrollPage(fromModel)) return;
 
+      fromModel.set('_isTrickleAutoScrollComplete', true);
+
       var trickle = Adapt.trickle.getModelConfig(fromModel);
+      var isAutoScrollOff = !trickle._autoScroll;
+      var hasTrickleButton = trickle._button._isEnabled;
+      if (isAutoScrollOff && !hasTrickleButton) {
+        return;
+      }
+
       var scrollTo = trickle._scrollTo;
-      if (scrollTo === undefined) scrollTo = "@block +1";
+      if (scrollTo === undefined) scrollTo = '@block +1';
 
-      fromModel.set("_isTrickleAutoScrollComplete", true);
-
-      var scrollToId = "";
+      var scrollToId = '';
       switch (scrollTo.substr(0,1)) {
-        case "@":
+        case '@':
           // NAVIGATE BY RELATIVE TYPE
 
           // Allows trickle to scroll to a sibling / cousin component
           // relative to the current trickle item
           var relativeModel = fromModel.findRelativeModel(scrollTo, {
             filter: function(model) {
-              return model.get("_isAvailable");
+              return model.get('_isAvailable');
             }
           });
 
           if (relativeModel === undefined) return;
-          scrollToId = relativeModel.get("_id");
+          scrollToId = relativeModel.get('_id');
           break;
-        case ".":
+        case '.':
           // NAVIGATE BY CLASS
           scrollToId = scrollTo.substr(1, scrollTo.length-1);
           break;
@@ -97,28 +103,26 @@ define([
           scrollToId = scrollTo;
       }
 
-      if (scrollToId == "") return;
+      if (scrollToId === '') return;
 
-      $("." + scrollToId).focusOrNext();
-
-      var isAutoScrollOff = (!trickle._autoScroll);
-      if (isAutoScrollOff) {
-        return false;
+      if (hasTrickleButton) { // only set focus if there's a trickle button - see https://github.com/adaptlearning/adapt_framework/issues/2813
+        Adapt.a11y.focusFirst($('.' + scrollToId));
       }
 
-      var duration = fromModel.get("_trickle")._scrollDuration || 500;
-      Adapt.scrollTo("." + scrollToId, { duration: duration });
+      if (isAutoScrollOff) return;
 
+      var duration = fromModel.get('_trickle')._scrollDuration || 500;
+      Adapt.scrollTo('.' + scrollToId, { duration: duration });
     },
 
     shouldScrollPage: function(fromModel) {
       var trickle = Adapt.trickle.getModelConfig(fromModel);
       if (!trickle || !trickle._isEnabled) return false;
 
-      var hasScrolled = fromModel.get("_isTrickleAutoScrollComplete");
+      var hasScrolled = fromModel.get('_isTrickleAutoScrollComplete');
       if (hasScrolled) return false;
 
-      var isArticleWithOnChildren = (fromModel.get("_type") === "article" && trickle._onChildren);
+      var isArticleWithOnChildren = (fromModel.get('_type') === 'article' && trickle._onChildren);
       if (isArticleWithOnChildren) return false;
 
       return true;
@@ -126,6 +130,6 @@ define([
 
   });
 
-  return Adapt.trickle = new Trickle();
+  return (Adapt.trickle = new Trickle());
 
 });


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/2813

also:
* return early if neither auto scroll nor trickle button enabled
* update to new a11y API
* double quotes > single
* bump version