### PR TITLE
issue/2924 remove "scroll" option from "_styleAfterClick"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >>**\_styleBeforeCompletion** (string):  Determines whether the Trickle button is visible even while subsequent sections of the page remain inaccessible. Acceptable values are `"hidden"` and `"visible"`. The default is `"hidden"`.
 
->>**\_styleAfterClick** (string): Determines the properties of the Trickle button after it has been clicked. Acceptable values are `"hidden"`, `"disabled"`, and `"scroll"`. `"hidden"` hides the button. `"disabled"` applies the "disabled" CSS class. The value `"scroll"` will cause the button to maintain its visibility allowing the user an alternative method for scrolling down the page by using the button (even after all sections have been revealed). The default is `"hidden"`.
+>>**\_styleAfterClick** (string): Determines the properties of the Trickle button after it has been clicked. Acceptable values are `"hidden"`, and `"disabled"`. `"hidden"` hides the button. The value `"disabled"` will cause the button to remain visible after the click. The default is `"hidden"`.
 
 >>**\_isFullWidth** (boolean):  Will position the button fixed to the bottom of the window. This option will force to `true`  **\_isEnabled** in the **\_stepLocking** attribute group (**\_stepLocking.\_isEnabled: true**). When **\_autoHide** is set to `true`, the button will fade-out when the learner scrolls up, away from the button. The default is `true`.
 

--- a/example.json
+++ b/example.json
@@ -15,7 +15,7 @@
             "_isEnabled": true,
             "_comment": "_styleBeforeCompletion = hidden | visible",
             "_styleBeforeCompletion": "hidden",
-            "_comment": "_styleAfterClick = hidden | disabled | scroll",
+            "_comment": "_styleAfterClick = hidden | disabled",
             "_styleAfterClick": "hidden",
             "_isFullWidth": true,
             "_comment": "_autoHide = it is recommended this be left set to false in courses that need to be screenreader-compatible.",

--- a/properties.schema
+++ b/properties.schema
@@ -119,10 +119,10 @@
                     "_styleAfterClick": {
                       "type": "string",
                       "required": false,
-                      "enum": ["hidden", "disabled", "scroll"],
+                      "enum": ["hidden", "disabled"],
                       "default": "hidden",
                       "title": "Final Visibility",
-                      "inputType": {"type": "Select", "options":["hidden", "disabled", "scroll"]},
+                      "inputType": {"type": "Select", "options":["hidden", "disabled"]},
                       "validators": ["required"],
                       "help": "Set button visibility after completion"
                     },


### PR DESCRIPTION
Trickle code did not reference the "scroll" option for "_styleAfterClick". This PR removes mention of that option from supporting files: README, example.json, and properties.schema.

[Note: The current behaviour for the option "disabled" _can_ include scrolling. I decided to retain "disabled"--even though the button is not disabled in anyway--because "disabled" is referenced in [JS code](https://github.com/adaptlearning/adapt-contrib-trickle/blob/fe0540834c61b15d5ba934c8977a7bc636381b49/js/handlers/buttonView.js#L276) and because I am proposing "disabled" be changed to "visible" in a separate issue https://github.com/adaptlearning/adapt_framework/issues/2925 ]

fixes https://github.com/adaptlearning/adapt_framework/issues/2924