### PR TITLE
issue/2925 change "disabled" to "visible" for "_styleAfterClick"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >>**\_styleBeforeCompletion** (string):  Determines whether the Trickle button is visible even while subsequent sections of the page remain inaccessible. Acceptable values are `"hidden"` and `"visible"`. The default is `"hidden"`.
 
->>**\_styleAfterClick** (string): Determines the properties of the Trickle button after it has been clicked. Acceptable values are `"hidden"`, `"disabled"`, and `"scroll"`. `"hidden"` hides the button. `"disabled"` applies the "disabled" CSS class. The value `"scroll"` will cause the button to maintain its visibility allowing the user an alternative method for scrolling down the page by using the button (even after all sections have been revealed). The default is `"hidden"`.
+>>**\_styleAfterClick** (string): Determines the properties of the Trickle button after it has been clicked. Acceptable values are `"hidden"`, and `"visible"`. `"hidden"` hides the button. The value `"visible"` will cause the button to remain visible after the click. The default is `"hidden"`.
 
 >>**\_isFullWidth** (boolean):  Will position the button fixed to the bottom of the window. This option will force to `true`  **\_isEnabled** in the **\_stepLocking** attribute group (**\_stepLocking.\_isEnabled: true**). When **\_autoHide** is set to `true`, the button will fade-out when the learner scrolls up, away from the button. The default is `true`.
 

--- a/example.json
+++ b/example.json
@@ -15,7 +15,7 @@
             "_isEnabled": true,
             "_comment": "_styleBeforeCompletion = hidden | visible",
             "_styleBeforeCompletion": "hidden",
-            "_comment": "_styleAfterClick = hidden | disabled | scroll",
+            "_comment": "_styleAfterClick = hidden | visible",
             "_styleAfterClick": "hidden",
             "_isFullWidth": true,
             "_comment": "_autoHide = it is recommended this be left set to false in courses that need to be screenreader-compatible.",

--- a/js/handlers/buttonView.js
+++ b/js/handlers/buttonView.js
@@ -273,8 +273,7 @@ define([
         this.allowVisible = false;
         this.checkButtonAutoHideSync();
         break;
-      case "disabled":
-        this.allowEnabled = false;
+      case "visible":
         this.checkButtonAutoHideSync();
       }
     },

--- a/properties.schema
+++ b/properties.schema
@@ -119,10 +119,10 @@
                     "_styleAfterClick": {
                       "type": "string",
                       "required": false,
-                      "enum": ["hidden", "disabled", "scroll"],
+                      "enum": ["hidden", "visible"],
                       "default": "hidden",
                       "title": "Final Visibility",
-                      "inputType": {"type": "Select", "options":["hidden", "disabled", "scroll"]},
+                      "inputType": {"type": "Select", "options":["hidden", "visible"]},
                       "validators": ["required"],
                       "help": "Set button visibility after completion"
                     },


### PR DESCRIPTION
This PR changes the value "disabled" to "visible" to better reflect the behaviour and to reduce confusion. 

fixes https://github.com/adaptlearning/adapt_framework/issues/2925