### PR TITLE
issue/3186 General bugs and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >>**\_component** (string):  Defines the Trickle plug-in which should handle the interaction. At present only `"trickle-button"` is available, but it is possible to create new plug-ins. The default is `"trickle-button"`.
 
+>>**\_showEndOfPage** (boolean):  When set to `false`, hides any end-of-page button. The default is `true`.
+
 >**\_stepLocking** (object):  Step locking (section hiding) attributes group contains values for **\_isEnabled**, **\_isCompletionRequired**, and **\_isLockedOnRevisit**.
 
 >>**\_isEnabled** (boolean):  Will allow Trickle to truncate the page at the step until the user is allowed to move forward. The default is `true`. Note that if **\_isFullWidth** is set to `true` on the **\_button** attribute group (see above), **\_isEnabled** will be forced to `true` regardless of what you set here.

--- a/example.json
+++ b/example.json
@@ -29,7 +29,8 @@
             "startAriaLabel": "",
             "finalText": "Finish",
             "finalAriaLabel": "",
-            "_component": "trickle-button"
+            "_component": "trickle-button",
+            "_showEndOfPage": true
         },
         "_stepLocking": {
             "_isEnabled": true,

--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -42,6 +42,9 @@ export default class TrickleButtonModel extends ComponentModel {
    */
   isStepUnlocked() {
     const completionAttribute = getCompletionAttribute();
+    // Check if completion is blocked by another extension
+    const isCompletionBlocked = (this.getParent().get('_requireCompletionOf') === Number.POSITIVE_INFINITY);
+    if (isCompletionBlocked) return;
     return this.getSiblings().every(sibling => {
       if (sibling === this) {
         return true;

--- a/js/TrickleButtonView.js
+++ b/js/TrickleButtonView.js
@@ -72,6 +72,7 @@ class TrickleButtonView extends ComponentView {
     const parentModel = this.model.getParent();
     const completionAttribute = getCompletionAttribute();
     this.listenTo(parentModel, {
+      'change:_requireCompletionOf': this.onStepUnlocked,
       [`bubble:change:${completionAttribute}`]: this.onStepUnlocked,
       [`change:${completionAttribute}`]: this.onParentComplete
     });

--- a/js/controller.js
+++ b/js/controller.js
@@ -17,7 +17,7 @@ class TrickleController extends Backbone.Controller {
     this.checkIsFinished = _.debounce(this.checkIsFinished, 1);
     this.listenTo(data, {
       // Check that the locking is accurate after any completion
-      'change:_isInteractionComplete change:_isComplete': checkApplyLocks,
+      'change:_isInteractionComplete change:_isComplete change:_isAvailable add remove': checkApplyLocks,
       // Check whether trickle is finished after any locking changes
       'change:_isLocked': this.checkIsFinished
     });
@@ -107,15 +107,16 @@ class TrickleController extends Backbone.Controller {
       const scrollTo = trickleConfig._scrollTo;
       const firstCharacter = scrollTo.substr(0, 1);
       switch (firstCharacter) {
-        case '@':
+        case '@': {
           // NAVIGATE BY RELATIVE TYPE
           // Allows trickle to scroll to a sibling / cousin component
           // relative to the current trickle item
-          var relativeModel = fromModel.findRelativeModel(scrollTo, {
+          const relativeModel = fromModel.findRelativeModel(scrollTo, {
             filter: model => model.get('_isAvailable')
           });
           if (relativeModel === undefined) return;
           return relativeModel.get('_id');
+        }
         case '.':
           // NAVIGATE BY CLASS
           return scrollTo.substr(1, scrollTo.length - 1);

--- a/js/models.js
+++ b/js/models.js
@@ -103,8 +103,8 @@ export function getModelInheritanceChain(configModel) {
     const parentModel = configModel.getParent();
     const parentConfig = parentModel.get('_trickle');
     const blockConfig = configModel.get('_trickle');
-    const isParentEnabledNotOnChildren = (parentConfig && parentConfig._isEnabled && parentConfig._onChildren === false);
-    const isNoChildConfig = (!blockConfig || !blockConfig._isEnabled);
+    const isParentEnabledNotOnChildren = (parentConfig?._isEnabled && parentConfig._onChildren === false);
+    const isNoChildConfig = (!blockConfig?._isEnabled);
     if (isParentEnabledNotOnChildren && isNoChildConfig) {
       return null;
     }

--- a/js/models.js
+++ b/js/models.js
@@ -283,7 +283,7 @@ export function addButtonComponents() {
  * Pretty print locking state for current page
  */
 export function logTrickleState() {
-  if (logging._config._level !== 'debug') return;
+  if (logging._config?._level !== 'debug') return;
   if (!Adapt.parentView?.model?.isTypeGroup('page')) {
     logging.debug('TRICKLE GLOBAL STATE');
     Adapt.course.getAllDescendantModels(true).filter(model => model.get('_isAvailable')).forEach(model => {


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3186
fixes https://github.com/adaptlearning/adapt_framework/issues/2623

### Changed
* Logging prints a full map of the trickle state of the course/page, indented to show structure (only when in debug logging state `?loglevel=debug` + verbose in chrome debugger)
* Locking is now `_isAvailable` aware
* Locking is now also applied when a model is added or removed or its `_isAvailable` is changed
* Fixed some linting issues
* When an article has trickle enabled but `_onChildren: false` and the block has no config, the block now no longer inherits the article config
* Added `_showEndOfPage` to `example.json` and readme
* When article `_requireCompletionOf === Infinity` do not consider the article complete as more blocks will be added (branching support)