### PR TITLE
issue/3205 Ensure articles without onChildren are onChildren: true

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -63,7 +63,8 @@ export const configDefaults = {
  */
 export function isModelArticleWithOnChildren(model) {
   const type = model.get('_type');
-  return (type === 'article' && model.get('_trickle')?._onChildren);
+  const trickleConfig = model.get('_trickle');
+  return (type === 'article' && trickleConfig && trickleConfig._onChildren !== false);
 }
 
 /**


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3205

### Fixed
* Article `_onChildren` should default to `true` throughout