### PR TITLE
issue/126 Fixed completion restore on new session

### DIFF
--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -66,7 +66,7 @@ export default class TrickleButtonModel extends ComponentModel {
    */
   isStepComplete() {
     const completionAttribute = getCompletionAttribute();
-    const isParentComplete = (this.getParent().get(completionAttribute));
+    const isParentComplete = this.getParent().get(completionAttribute);
     return isParentComplete;
   }
 

--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -8,6 +8,12 @@ import {
 
 export default class TrickleButtonModel extends ComponentModel {
 
+  init() {
+    super.init();
+    if (!this.isStepComplete()) return;
+    this.setCompletionStatus();
+  }
+
   /**
    * @returns {boolean} true if the button is enabled in its trickle configuration
    */
@@ -53,6 +59,15 @@ export default class TrickleButtonModel extends ComponentModel {
         sibling.get('_isOptional') ||
         !sibling.get('_isAvailable');
     });
+  }
+
+  /**
+   * @returns {boolean} true if the parent container is already complete
+   */
+  isStepComplete() {
+    const completionAttribute = getCompletionAttribute();
+    const isParentComplete = (this.getParent().get(completionAttribute));
+    return isParentComplete;
   }
 
   /**


### PR DESCRIPTION
fixes #126 

### Fixed
* when trickle model is created it now checks to see if it should be complete or not

### Added
* check to see if the parent article/block is complete