### PR TITLE
issue/129 Part fix for branching conflict

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -36,7 +36,7 @@ class TrickleController extends Backbone.Controller {
 
   async onDataReady() {
     await data.whenReady();
-    Adapt.wait.for((done) => {
+    Adapt.wait.for(done => {
       addButtonComponents();
       applyLocks();
       done();

--- a/js/controller.js
+++ b/js/controller.js
@@ -36,8 +36,11 @@ class TrickleController extends Backbone.Controller {
 
   async onDataReady() {
     await data.whenReady();
-    addButtonComponents();
-    applyLocks();
+    Adapt.wait.for((done) => {
+      addButtonComponents();
+      applyLocks();
+      done();
+    });
   }
 
   /**


### PR DESCRIPTION
fixes #129 

### Fixed
* Pushed trickle button creation and locking initialization to the final point in the startup process after `app:dataReady` (after spoor restoration), branching and assessment and before `adapt:start`