### PR TITLE
issue/133 Added debounce to wait for autoscroll question feedback notify

### DIFF
--- a/js/TrickleButtonView.js
+++ b/js/TrickleButtonView.js
@@ -59,6 +59,8 @@ class TrickleButtonView extends ComponentView {
 
   setupEventListeners() {
     this.tryButtonAutoHide = this.tryButtonAutoHide.bind(this);
+    // Add debounce to wait for autoscroll question feedback notify to appear
+    this.onParentComplete = _.debounce(this.onParentComplete.bind(this), 100);
     this.listenTo(Adapt.parentView, 'postRemove', this.onRemove);
     this.listenTo(Adapt, 'trickle:killed', this.updateButtonState);
     if (this.model.isStepUnlocked() && this.model.isFinished()) {


### PR DESCRIPTION
fixes #133 

### Fixed
* Added debounce to `onParentComplete` to wait for question feedback notify to appear on autoscroll, no button trickle configs