### PR TITLE
issue/139 Asynchronously apply locking where possible

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -17,13 +17,13 @@ class TrickleController extends Backbone.Controller {
   initialize() {
     this.checkIsFinished = _.debounce(this.checkIsFinished, 1);
     this.listenTo(data, {
-      // Check that the locking is accurate after any completion
+      // Check that the locking is accurate after any completion, this happens asynchronously
       'change:_isInteractionComplete change:_isComplete change:_isAvailable add remove': checkApplyLocks,
       // Check whether trickle is finished after any locking changes
       'change:_isLocked': this.checkIsFinished
     });
     this.listenTo(Adapt, {
-      // Reapply locks after assessment reset, this happens asynchronously
+      // Reapply locks after assessment reset, this happens asynchronously where possible
       'assessments:reset': this.onAssessmentReset,
       // Reset trickle's global state when changing content objects
       'contentObjectView:preRender': this.reset,
@@ -36,7 +36,7 @@ class TrickleController extends Backbone.Controller {
   }
 
   onAssessmentReset() {
-    // If mid render the apply locks immediately
+    // If mid render then apply locks immediately
     const isMidRender = !Adapt.parentView?.model.get('_isReady');
     if (isMidRender) return applyLocks();
     // Otherwise apply them lazily

--- a/js/models.js
+++ b/js/models.js
@@ -168,7 +168,7 @@ export function getCompletionAttribute() {
 export function checkApplyLocks(model) {
   const completionAttribute = getCompletionAttribute();
   if (!Object.prototype.hasOwnProperty.call(model.changed, completionAttribute)) return;
-  applyLocks();
+  debouncedApplyLocks();
 }
 
 /**
@@ -221,6 +221,8 @@ export function applyLocks() {
   });
   logTrickleState();
 }
+
+export const debouncedApplyLocks = _.debounce(applyLocks, 1);
 
 /**
  * Returns all of the contentobject descendant models directly subsequent to the
@@ -316,6 +318,7 @@ export default {
   getCompletionAttribute,
   checkApplyLocks,
   applyLocks,
+  debouncedApplyLocks,
   _getAncestorNextSiblings,
   addButtonComponents,
   logTrickleState

--- a/js/models.js
+++ b/js/models.js
@@ -168,6 +168,7 @@ export function getCompletionAttribute() {
 export function checkApplyLocks(model) {
   const completionAttribute = getCompletionAttribute();
   if (!Object.prototype.hasOwnProperty.call(model.changed, completionAttribute)) return;
+  // Apply the locks lazily
   debouncedApplyLocks();
 }
 


### PR DESCRIPTION
fixes #139 

### Fixed
* Locking is applied asynchronously where multiple assessment are reset outside of a page refresh and after questions are reset or submitted.