### PR TITLE
issue/2799 Remove redundant behaviour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-trickle",
   "version": "5.2.5",
-  "framework": ">=5.8",
+  "framework": ">=5.19.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-trickle",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-trickle/issues",
   "extension" : "trickle",

--- a/js/TrickleButtonView.js
+++ b/js/TrickleButtonView.js
@@ -119,7 +119,7 @@ class TrickleButtonView extends ComponentView {
     const isButtonDisabled = this.model.get('_isButtonDisabled');
     const $button = this.$('.js-trickle-btn');
     const $ariaLabel = this.$('.aria-label');
-    Adapt.a11y.toggleEnabled($button, !isButtonDisabled);
+    a11y.toggleEnabled($button, !isButtonDisabled);
     if (!isButtonDisabled) {
       // move focus forward if it's on the aria-label
       if (document.activeElement instanceof HTMLElement && document.activeElement.isSameNode($ariaLabel[0])) {

--- a/js/controller.js
+++ b/js/controller.js
@@ -1,4 +1,6 @@
 import Adapt from 'core/js/adapt';
+import wait from 'core/js/wait';
+import components from 'core/js/components';
 import data from 'core/js/data';
 import a11y from 'core/js/a11y';
 import {
@@ -9,6 +11,7 @@ import {
   getModelConfig,
   isModelArticleWithOnChildren
 } from './models';
+import router from 'core/js/router';
 
 /** @typedef {import('core/js/childEvent').default} ChildEvent  */
 
@@ -17,7 +20,7 @@ class TrickleController extends Backbone.Controller {
   initialize() {
     this.checkIsFinished = _.debounce(this.checkIsFinished, 1);
     this.listenTo(data, {
-      'ready': this.onDataReady,
+      ready: this.onDataReady,
       // Check that the locking is accurate after any completion, this happens asynchronously
       'change:_isInteractionComplete change:_isComplete change:_isAvailable add remove': checkApplyLocks,
       // Check whether trickle is finished after any locking changes
@@ -44,7 +47,7 @@ class TrickleController extends Backbone.Controller {
   }
 
   async onDataReady() {
-    Adapt.wait.for(done => {
+    wait.for(done => {
       addButtonComponents();
       applyLocks();
       done();
@@ -145,12 +148,12 @@ class TrickleController extends Backbone.Controller {
     if (!isDescendant) {
       applyLocks();
       // Navigate to another content object
-      const model = Adapt.findById(scrollToId);
+      const model = data.findById(scrollToId);
       const contentObject = model.isTypeGroup('contentobject') ? model : model.findAncestor('contentobject');
-      await Adapt.navigateToElement(contentObject.get('_id'));
+      await router.navigateToElement(contentObject.get('_id'));
       // Recalculate the relative id after the page is ready as it may change
       scrollToId = getScrollToId();
-      await Adapt.navigateToElement(scrollToId);
+      await router.navigateToElement(scrollToId);
       return;
     }
 
@@ -164,7 +167,7 @@ class TrickleController extends Backbone.Controller {
     if (isAutoScrollOff) return false;
 
     const duration = trickleConfig._scrollDuration || 500;
-    Adapt.scrollTo('.' + scrollToId, { duration });
+    router.navigateToElement('.' + scrollToId, { duration });
   }
 
   /**
@@ -194,7 +197,7 @@ class TrickleController extends Backbone.Controller {
    */
   async kill() {
     // Fetch the component model from the store incase it needs overriding by another extension
-    const TrickleModel = Adapt.getModelClass('trickle-button');
+    const TrickleModel = components.getModelClass('trickle-button');
     this.isKilled = true;
     Adapt.parentView.model.getAllDescendantModels().forEach(model => {
       const isButtonModel = (model instanceof TrickleModel);

--- a/js/models.js
+++ b/js/models.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import data from 'core/js/data';
 import logging from 'core/js/logging';
 import ContentObjectModel from 'core/js/models/contentObjectModel';
@@ -182,7 +183,7 @@ export function applyLocks() {
   const locks = {};
   const modelsById = {};
   // Fetch the component model from the store incase it needs overriding by another extension
-  const TrickleButtonModel = Adapt.getModelClass('trickle-button');
+  const TrickleButtonModel = components.getModelClass('trickle-button');
   // Check all models for trickle potential
   Adapt.course.getAllDescendantModels(true).filter(model => model.get('_isAvailable')).forEach(siteModel => {
     const trickleConfig = getModelConfig(siteModel);
@@ -259,7 +260,7 @@ export function _getAncestorNextSiblings(fromModel) {
  */
 export function addButtonComponents() {
   // Fetch the component model from the store incase it needs overriding by another extension
-  const TrickleButtonModel = Adapt.getModelClass('trickle-button');
+  const TrickleButtonModel = components.getModelClass('trickle-button');
   let uid = 0;
   data.forEach(buttonModelSite => {
     if (buttonModelSite instanceof CourseModel) return;

--- a/js/trickleButton.js
+++ b/js/trickleButton.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import TrickleButtonView from './TrickleButtonView';
 import TrickleButtonModel from './TrickleButtonModel';
 
-export default Adapt.register('trickle-button', {
+export default components.register('trickle-button', {
   view: TrickleButtonView,
   model: TrickleButtonModel
 });


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to `components.register` from `Adapt.register`
* Use `a11y`, `wait` and `router` directly