### PR TITLE
issue/150 Do not lock children blocks with custom locking

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -206,6 +206,8 @@ export function applyLocks() {
       // Don't unlock anything that was locked in a previous group
       modelsById[id] = model;
       locks[id] = locks[id] || isLocked;
+      // Don't modify the children if they are managed by another locking mechanism
+      if (model.get('_lockType')) return;
       // Cascade inherited locks through the hierarchyd
       model.getAllDescendantModels().forEach(descendant => {
         const descendantId = descendant.get('_id');


### PR DESCRIPTION
fixes #150 

### Fixed
* Children block locks are not modified if the article has a `_lockType` specified