### PR TITLE
issue/155 Fixed _isCompletionRequired: false

### DIFF
--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -3,7 +3,8 @@ import ComponentModel from 'core/js/models/componentModel';
 import {
   getModelContainer,
   getModelConfig,
-  getCompletionAttribute
+  getCompletionAttribute,
+  applyLocks
 } from './models';
 
 export default class TrickleButtonModel extends ComponentModel {
@@ -139,11 +140,12 @@ export default class TrickleButtonModel extends ComponentModel {
    * on revisit
    */
   checkIfResetOnRevisit() {
-    if (this.isStepUnlocked() && !this.isStepLockedOnRevisit()) return;
+    if (this.isFinished() && !this.isStepLockedOnRevisit()) return;
     this.set({
       _isComplete: false,
       _isInteractionComplete: false
     });
+    applyLocks();
   }
 
   /**

--- a/js/models.js
+++ b/js/models.js
@@ -197,12 +197,8 @@ export function applyLocks() {
   // Check all models for trickle potential
   Adapt.course.getAllDescendantModels(true).filter(model => model.get('_isAvailable')).forEach(siteModel => {
     const trickleConfig = getModelConfig(siteModel);
-    if (!trickleConfig || !trickleConfig._isEnabled) return;
-    const isStepLocked = Boolean(trickleConfig?._stepLocking?._isEnabled);
-    const completionAttribute = getCompletionAttribute(siteModel);
-    const isLocked = isStepLocked &&
-      !siteModel?.get(completionAttribute) &&
-      !siteModel?.get('_isOptional');
+    if (!isEnabled(siteModel, { trickleConfig })) return;
+    const isModelLocked = isLocked(siteModel, { trickleConfig });
     const id = siteModel.get('_id');
     modelsById[id] = siteModel;
     locks[id] = locks[id] || false;
@@ -216,7 +212,7 @@ export function applyLocks() {
       // Store the new locking state of each model in the locks variable
       // Don't unlock anything that was locked in a previous group
       modelsById[id] = model;
-      locks[id] = locks[id] || isLocked;
+      locks[id] = locks[id] || isModelLocked;
       // Don't modify the children if they are managed by another locking mechanism
       if (model.get('_lockType')) return;
       // Cascade inherited locks through the hierarchyd
@@ -228,13 +224,33 @@ export function applyLocks() {
     });
   });
   // Apply only changed locking states
-  Object.entries(locks).forEach(([ id, isLocked ]) => {
+  Object.entries(locks).forEach(([ id, isModelLocked ]) => {
     const model = modelsById[id];
     const wasLocked = model.get('_isLocked');
-    if (wasLocked === isLocked) return;
-    model.set('_isLocked', isLocked);
+    if (wasLocked === isModelLocked) return;
+    model.set('_isLocked', isModelLocked);
   });
   logTrickleState();
+}
+
+export function isEnabled(model, { trickleConfig = getModelConfig(model) } = {}) {
+  return (trickleConfig?._isEnabled === true);
+}
+
+export function isLocked(model, { trickleConfig = getModelConfig(model) } = {}) {
+  const isStepLocked = Boolean(trickleConfig?._stepLocking?._isEnabled);
+  if (!isStepLocked) return false;
+  const isCompletionRquired = Boolean(trickleConfig?._stepLocking?._isCompletionRequired);
+  const completionAttribute = getCompletionAttribute(model);
+  if (!isCompletionRquired) {
+    const TrickleModel = components.getModelClass('trickle-button');
+    const trickleButton = model.getAvailableChildModels().find(model => model instanceof TrickleModel);
+    const isTrickleButtonComplete = Boolean(trickleButton?.get(completionAttribute));
+    return !isTrickleButtonComplete;
+  }
+  const isModelLocked = !model?.get(completionAttribute) &&
+    !model?.get('_isOptional');
+  return isModelLocked;
 }
 
 export const debouncedApplyLocks = _.debounce(applyLocks, 1);

--- a/js/models.js
+++ b/js/models.js
@@ -240,9 +240,9 @@ export function isEnabled(model, { trickleConfig = getModelConfig(model) } = {})
 export function isLocked(model, { trickleConfig = getModelConfig(model) } = {}) {
   const isStepLocked = Boolean(trickleConfig?._stepLocking?._isEnabled);
   if (!isStepLocked) return false;
-  const isCompletionRquired = Boolean(trickleConfig?._stepLocking?._isCompletionRequired);
+  const isCompletionRequired = Boolean(trickleConfig?._stepLocking?._isCompletionRequired);
   const completionAttribute = getCompletionAttribute(model);
-  if (!isCompletionRquired) {
+  if (!isCompletionRequired) {
     const TrickleModel = components.getModelClass('trickle-button');
     const trickleButton = model.getAvailableChildModels().find(model => model instanceof TrickleModel);
     const isTrickleButtonComplete = Boolean(trickleButton?.get(completionAttribute));


### PR DESCRIPTION
#155 

### Fixed
* Reset on revisit applies to the button only after its completed according to the various steplocked/completion required criteria. Switched from using `isStepLocked` to `isFinished` which includes `_isCompletionRequired: false` calculations.
* Moved `isLocked` behaviour from `applyLocks` into its own function and added `_isCompletionRequired: false` calculations to check for the button completion instead.