### PR TITLE
Fix: Add position: relative; to trickle btn (fixes #170)

### DIFF
--- a/less/trickle-button.less
+++ b/less/trickle-button.less
@@ -8,6 +8,7 @@
   }
 
   &__btn {
+    position: relative;
     display: block;
     margin: auto;
   }


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-trickle/issues/170

### Fix
* Added `position: relative;` to `trickle__btn` to resolve conflict between newly introduced Vanilla background div and Trickle. Trickle button was unable to be selected if Trickle's `_isFullWidth` was set to `false` due to z-index issue.
