### PR TITLE
Breaking: Replace @navigation-height with --adapt-navigation-height (fixes #187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ No known limitations.
 
 ----------------------------
 <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-trickle/graphs/contributors)
-**Accessibility support:** WAI AA
-**RTL support:** Yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-trickle/graphs/contributors)<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera<br>

--- a/less/trickle-button.less
+++ b/less/trickle-button.less
@@ -30,7 +30,7 @@
     right: 0;
   }
 
-  // If full width config is enabled, button is fixed to the bottm of the screen
+  // If full width config is enabled, button is fixed to the bottom of the screen
   // --------------------------------------------------
   &.is-full-width &__inner {
     position: fixed;

--- a/less/trickle-button.less
+++ b/less/trickle-button.less
@@ -42,7 +42,7 @@
     }
 
     html.is-nav-bottom & {
-      bottom: @navigation-height;
+      bottom: var(--adapt-navigation-height);
     }
   }
 }


### PR DESCRIPTION
Fixes #187

### Breaking
* Replaces `@navigation-height` with `--adapt-navigation-height` CSS variable

### Testing

1. In _course.json_, set `_navigation._navigationAlignment` to 'bottom'
2. Enable Trickle on some blocks
3. Ensure Navigation and/or Trickle aren't overlapping each other

### Dependencies
**Core** - Navigation Button API
https://github.com/adaptlearning/adapt-contrib-core/pull/339 


