### PR TITLE
Fix: Add buttons after data ready (fixes #205)

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -20,7 +20,7 @@ class TrickleController extends Backbone.Controller {
 
   initialize() {
     this.checkIsFinished = _.debounce(this.checkIsFinished, 1);
-    this.listenTo(data, "ready", this.onDataReady);
+    this.listenTo(data, 'ready', this.onDataReady);
     this.listenTo(Adapt, 'adapt:start', this.onAdaptStart);
   }
 
@@ -161,8 +161,8 @@ class TrickleController extends Backbone.Controller {
 
     let scrollToId = getScrollToId();
     if (!scrollToId) {
-      logging.error(`Cannot scroll to the next id as none was found at id: "${fromModel.get('_id')}" with _scrollTo: "${trickleConfig._scrollTo}". Suggestion: Set _showEndOfPage to false.`)
-      return
+      logging.error(`Cannot scroll to the next id as none was found at id: "${fromModel.get('_id')}" with _scrollTo: "${trickleConfig._scrollTo}". Suggestion: Set _showEndOfPage to false.`);
+      return;
     }
 
     const isDescendant = Adapt.parentView.model.getAllDescendantModels().some(model => {

--- a/js/controller.js
+++ b/js/controller.js
@@ -20,20 +20,21 @@ class TrickleController extends Backbone.Controller {
 
   initialize() {
     this.checkIsFinished = _.debounce(this.checkIsFinished, 1);
+    this.listenTo(data, "ready", this.onDataReady);
+    this.listenTo(Adapt, 'adapt:start', this.onAdaptStart);
+  }
 
-    this.listenTo(Adapt, {
-      'adapt:start': this.onAdaptStart
-    });
+  async onDataReady() {
+    const trickleConfig = Adapt.config.get('_trickle');
+    if (trickleConfig?._isEnabled === false) return;
+    addButtonComponents();
   }
 
   async onAdaptStart() {
     const trickleConfig = Adapt.config.get('_trickle');
     if (trickleConfig?._isEnabled === false) return;
-
     this.setUpEventListeners();
-
     wait.for(done => {
-      addButtonComponents();
       applyLocks();
       done();
     });


### PR DESCRIPTION
fixes #205 

### Fix
* Wait for data ready before adding buttons. This is after spoor has restored and before assessment has captured its children. This allows assessment to correctly manage trickled blocks.