### PR TITLE
New: 'is-locked' btn class added

### DIFF
--- a/js/TrickleButtonView.js
+++ b/js/TrickleButtonView.js
@@ -128,6 +128,8 @@ class TrickleButtonView extends ComponentView {
       // make label unfocusable as it is no longer needed
       a11y.toggleAccessibleEnabled($ariaLabel, false);
     }
+    const isButtonLocked = (this.model.get('_isButtonVisible')) && isButtonDisabled;
+    $button.toggleClass('is-locked', isButtonLocked);
     const $buttonText = this.$('.js-trickle-btn-text');
     const text = this.model.get('buttonText');
     const ariaLabel = this.model.get('buttonAriaLabel');

--- a/templates/trickle-button.hbs
+++ b/templates/trickle-button.hbs
@@ -2,7 +2,7 @@
 
 <div class="trickle__inner js-trickle-btn-container {{_trickle._button._component}}__inner {{#unless _isButtonVisible}} u-display-none{{/unless}}">
 
-  <button {{#if buttonAriaLabel}}aria-label="{{buttonAriaLabel}}" {{/if}}class="trickle__btn js-trickle-btn {{#if _isButtonDisabled}} is-disabled{{/if}}{{#if _trickle._button._hasIcon}} btn-icon{{/if}}{{#if buttonText}} btn-text{{/if}}"{{#if _isButtonDisabled}} aria-disabled="true"{{/if}}>
+  <button {{#if buttonAriaLabel}}aria-label="{{buttonAriaLabel}}" {{/if}}class="trickle__btn js-trickle-btn{{#if _trickle._button._hasIcon}} btn-icon{{/if}}{{#if buttonText}} btn-text{{/if}}"{{#if _isButtonDisabled}} aria-disabled="true"{{/if}}>
 
     {{#if _trickle._button._hasIcon}}
     <span class="trickle__btn-icon">


### PR DESCRIPTION
#### Add `.is-locked` state class

Relates to Core issue to [allow for locked and inactive disabled buttons to be visually different](https://github.com/adaptlearning/adapt-contrib-core/issues/485). Depending on the button context, the appropriate `.is-locked` or `.is-disabled` classes should be used.

`.is-locked` - applies to buttons that are temporarily disabled due to step locked content.

`.is-disabled` - applies to buttons with functionality not available.

There are no specific Trickle button styles currently. Colours inherit from Vanilla `.btn-text` and `.btn-icon` classes instead which already include [.is-locked](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/1354de838956523d0463dcf7ee409b9b6261f7dd/less/core/button.less#L40) so no further styling required.

`.btn-text` and `.btn-icon` locked states inherit from the disabled state by default so there will be no visual changes. By introducing `.is-locked` class, this gives the flexibility of setting locked styling that can differ from the standard disabled styling.

#### Remove hbs 'is-disabled' btn class
The toggling of `.is-disabled` btn class is handled via `toggleEnabled` [in TrickleButtonView.js](https://github.com/adaptlearning/adapt-contrib-trickle/blob/82a1c23f24f6508d6ed8c0a65e23ddb11ae9d8ad/js/TrickleButtonView.js#L122). The hbs `.is-disabled` btn class had no impact on this so I've removed as this might cause confusion as to where the classes are applied.