### PR TITLE
Fix: Use parent children instead of stored siblings

### DIFF
--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -56,7 +56,8 @@ export default class TrickleButtonModel extends ComponentModel {
     // Check if completion is blocked by another extension
     const isCompletionBlocked = (parentModel.get('_requireCompletionOf') === Number.POSITIVE_INFINITY);
     if (isCompletionBlocked) return;
-    return this.getSiblings().every(sibling => {
+    // use getParent().getChildren() instead of getSiblings() as children change but siblings don't
+    return this.getParent().getChildren().every(sibling => {
       if (sibling === this) {
         return true;
       }


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-assessment/issues/192

### Fix
* Use parent children instead of stored siblings as children are modified by assessment randomisation and banking but siblings are not