### PR TITLE
Update: remove legacy locked styling (fixes #215)

### DIFF
--- a/less/trickle-button.less
+++ b/less/trickle-button.less
@@ -21,15 +21,6 @@
     .icon-controls-small-down;
   }
 
-  // Adds the necessary styling to lock the button
-  // --------------------------------------------------
-  &.is-locked {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
-
   // If full width config is enabled, button is fixed to the bottom of the screen
   // --------------------------------------------------
   &.is-full-width &__inner {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-trickle/issues/215

### Update
Removed redundant styles as `.is-locked` never gets appended to the `.trickle` element. Legacy code which pre dates v5 release.

`.is-locked` is only used for button elements to attach state styles as per [`.trickle__btn`](https://github.com/adaptlearning/adapt-contrib-trickle/blob/f4e75b2e946c4db3a7be4b230958f7538ba31ca0/js/TrickleButtonView.js#L132).



