### PR TITLE
Update: padlock replaces icon when trickle button locked (#217)

### DIFF
--- a/less/trickle-button.less
+++ b/less/trickle-button.less
@@ -21,6 +21,10 @@
     .icon-controls-small-down;
   }
 
+  &__btn.is-locked &__btn-icon .icon {
+    .icon-padlock-locked;
+  }
+  
   // If full width config is enabled, button is fixed to the bottom of the screen
   // --------------------------------------------------
   &.is-full-width &__inner {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-trickle/issues/217

### Update
As per [Vanilla issue #446](https://github.com/adaptlearning/adapt-contrib-vanilla/issues/446), locked disabled buttons should display a padlock icon. 

### Testing
Enable the following on `_trickle._button`:
```
        "_styleBeforeCompletion": "visible",
        "_hasIcon": true
```
Trickle button should display a padlock icon whilst locked.

<img width="575" alt="trickle_btn_locked" src="https://github.com/adaptlearning/adapt-contrib-trickle/assets/7045330/ae2d452d-6927-4d91-a780-f8ab6f05701b">
<br>
<br>
On completing content, trickle button should unlock and the standard chevron icon displays.
<br>
<br>
<img width="569" alt="trickle_btn_unlocked" src="https://github.com/adaptlearning/adapt-contrib-trickle/assets/7045330/ead33159-e463-4a1d-8265-4b5a9fb16cbb">

