### PR TITLE
Fix: _showEndOfPage button locking (#200) and page completion (#201)

### DIFF
--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -86,14 +86,8 @@ export default class TrickleButtonModel extends ComponentModel {
   }
 
   /**
-   * Trickle no longer locks this page (killed) but this end-of-page button was
-   * left incomplete on a previous visit. As the button is part of the page
-   * completion data, leaving it incomplete blocks the page from ever
-   * completing on revisit. Complete it so it no longer blocks completion.
-   * Scoped to the end-of-page button as that is the only button which can be
-   * left incomplete once all page content is complete (other step buttons must
-   * be clicked to progress, or auto-complete when disabled).
-   * @returns {boolean} true if the button should be completed on revisit
+   * @returns {boolean} true if an end-of-page button left incomplete on a
+   * previous visit should be completed so it stops blocking page completion
    */
   shouldCompleteOnRevisit() {
     if (this.get('_isComplete')) return false;

--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -86,14 +86,18 @@ export default class TrickleButtonModel extends ComponentModel {
   }
 
   /**
-   * Trickle no longer locks this page (killed) but this button was left
-   * incomplete on a previous visit. As the button is part of the page
+   * Trickle no longer locks this page (killed) but this end-of-page button was
+   * left incomplete on a previous visit. As the button is part of the page
    * completion data, leaving it incomplete blocks the page from ever
    * completing on revisit. Complete it so it no longer blocks completion.
+   * Scoped to the end-of-page button as that is the only button which can be
+   * left incomplete once all page content is complete (other step buttons must
+   * be clicked to progress, or auto-complete when disabled).
    * @returns {boolean} true if the button should be completed on revisit
    */
   shouldCompleteOnRevisit() {
     if (this.get('_isComplete')) return false;
+    if (!this.isLastInContentObject()) return false;
     if (this.isStepLockedOnRevisit()) return false;
     if (!this.isStepUnlocked()) return false;
     return controller.isKilled;

--- a/js/TrickleButtonModel.js
+++ b/js/TrickleButtonModel.js
@@ -86,6 +86,20 @@ export default class TrickleButtonModel extends ComponentModel {
   }
 
   /**
+   * Trickle no longer locks this page (killed) but this button was left
+   * incomplete on a previous visit. As the button is part of the page
+   * completion data, leaving it incomplete blocks the page from ever
+   * completing on revisit. Complete it so it no longer blocks completion.
+   * @returns {boolean} true if the button should be completed on revisit
+   */
+  shouldCompleteOnRevisit() {
+    if (this.get('_isComplete')) return false;
+    if (this.isStepLockedOnRevisit()) return false;
+    if (!this.isStepUnlocked()) return false;
+    return controller.isKilled;
+  }
+
+  /**
    * @return {boolean} true if completion is not required or if completion has been fulfilled
    * and the button has been clicked
    */

--- a/js/TrickleButtonView.js
+++ b/js/TrickleButtonView.js
@@ -39,6 +39,10 @@ class TrickleButtonView extends ComponentView {
     if (!this.model.isEnabled()) {
       this.setCompletionStatus();
     }
+    if (this.model.shouldCompleteOnRevisit()) {
+      this.model.setCompletionStatus();
+      this.updateButtonState();
+    }
     _.defer(this.setReadyStatus.bind(this));
   }
 

--- a/js/controller.js
+++ b/js/controller.js
@@ -172,6 +172,8 @@ class TrickleController extends Backbone.Controller {
       // Navigate to another content object
       const model = data.findById(scrollToId);
       const contentObject = model.isTypeGroup('contentobject') ? model : model.findAncestor('contentobject');
+      // Do not allow navigation into locked content (#200)
+      if (model.get('_isLocked') || contentObject.get('_isLocked')) return;
       await router.navigateToElement(contentObject.get('_id'));
       // Recalculate the relative id after the page is ready as it may change
       scrollToId = getScrollToId();


### PR DESCRIPTION
## What

Fixes two bugs with the `_showEndOfPage` end-of-page trickle button.

### Fixes #200 — button could navigate into locked content

The end-of-page button performs forward cross-page navigation via `controller.scroll()`, but did not check whether the target was locked. `scroll()` now bails out of the cross-page branch when the resolved `scrollTo` model or its content object is `_isLocked`, so the button can no longer take the learner into locked content.

### Fixes #201 — button could prevent page completion on revisit

The button is part of the page's completion data. If it was displayed but left unclicked, then the learner navigated away, the page could never complete: on return the button was hidden (trickle is no longer locking the page) yet still counted as incomplete, deadlocking completion.

`TrickleButtonModel.shouldCompleteOnRevisit()` detects this state (button incomplete, step unlocked, not locked-on-revisit, and trickle killed for the page) and the view completes the button on revisit so it no longer blocks page completion.

## ‼️ Behaviour change

As a consequence of the #201 fix, clicking the end-of-page button is _no longer mandatory_ for page completion on revisit. First-visit click-to-navigate behaviour is unchanged.

## Testing

Verified in a build with dedicated test pages:

- #200: completing a step-locking page and clicking the end-of-page button no longer enters a locked next page; navigation to an unlocked target still works.
- #201: completing all content but leaving the end-of-page button unclicked, navigating away and returning now completes the page; first-visit behaviour and already-complete-page revisits are unaffected.

Posted via collaboration with Claude Code