### PR TITLE
Fix: unlocking behind popups on returning visits (fixes #263).

### DIFF
--- a/js/TrickleButtonView.js
+++ b/js/TrickleButtonView.js
@@ -29,7 +29,6 @@ class TrickleButtonView extends ComponentView {
   }
 
   initialize() {
-    this.openPopupCount = 0;
     this.isAwaitingPopupClose = false;
     this.wasButtonClicked = false;
     this.calculateButtonState();
@@ -46,7 +45,7 @@ class TrickleButtonView extends ComponentView {
    * Taking account of open popups, recalculate the button visible and enabled states
    */
   calculateButtonState() {
-    const isDisabledByPopups = (this.openPopupCount > 0);
+    const isDisabledByPopups = a11y.isPopupOpen;
     this.model.calculateButtonState(isDisabledByPopups, this.wasButtonClicked);
   }
 
@@ -83,22 +82,14 @@ class TrickleButtonView extends ComponentView {
     });
   }
 
-  /**
-   * Keep count of the number of open popups
-   */
   onPopupOpened() {
-    this.openPopupCount++;
     const shouldUserInteractWithButton = (this.model.isStepUnlocked() && !this.model.isFinished());
     if (!shouldUserInteractWithButton) return;
     this.updateButtonState();
   }
 
-  /**
-   * Keep count of the number of open popups
-   */
   async onPopupClosed() {
-    this.openPopupCount--;
-    if (this.openPopupCount) return;
+    if (a11y.isPopupOpen) return;
     if (this.isAwaitingPopupClose) {
       // Had completed with an open popup, perform final part of finishing
       return this.finish();
@@ -173,7 +164,7 @@ class TrickleButtonView extends ComponentView {
       [`change:${completionAttribute}`]: this.onParentComplete
     });
     if (controller.isKilled) return;
-    if (this.openPopupCount > 0) {
+    if (a11y.isPopupOpen) {
       // Has completed with an open popup, defer finish until popup closed
       this.isAwaitingPopupClose = true;
       return;


### PR DESCRIPTION
Fixes #263.

Switched from an internal counter to the global popup stack, as any popup already open before the trickle button is created yields an unmatched close and drifts to a negative count, negating the popup guards in `isAwaitingPopupClose` and `onParentComplete`.

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* unlocking behind popups on returning visits - switched from an internal counter to the global popup stack

